### PR TITLE
Add Option to get Albums from Spotify 'liked songs' playlist

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ s = requests.session()
 CLIENT_ID = ""
 CLIENT_SECRET = ""
 LASTFM_KEY = ""
+CHECK_LIKED_SONGS = False
 
 
 @app.route('/')
@@ -35,9 +36,13 @@ def login():
 def spotify_results(token):
     """Open results page with Spotify data."""
     user = Spotify(token)
-    user.get_eligible_albums()
+    
+    if (CHECK_LIKED_SONGS):
+        user.get_elligible_albums_from_liked_songs()
+    else:
+        user.get_eligible_albums()
     scored_albums, unscored_albums = get_user_scores(user.eligible_albums)
-
+    
     if len(user.eligible_albums) < 1:
         return render_template('error.html', message="you have no eligible albums")
 


### PR DESCRIPTION
Personally, I never remember to save albums. This change allows scanning your Liked Songs playlist instead.

Boolean CHECK_LIKED_SONGS in app.py will enable the feature

#### My results:
 - Before: 236 albums in total | 114 albums are eligible | 5 albums with a score
 - After: 1252 albums in total | 518 albums are eligible | 45 albums with a score

#### Performance:
 - Before: 5.22 seconds
 - After: 21.81 seconds